### PR TITLE
fix scope override

### DIFF
--- a/lib/omniauth/strategies/discord.rb
+++ b/lib/omniauth/strategies/discord.rb
@@ -45,7 +45,7 @@ module OmniAuth
       def authorize_params
         super.tap do |params|
           options[:authorize_options].each do |option|
-            params[option] = request.params[option.to_s]
+            params[option] = request.params[option.to_s] if request.params[option.to_s]
           end
 
           params[:redirect_uri] = options[:redirect_uri] unless options[:redirect_uri].nil?


### PR DESCRIPTION
The following does not work:
```
Rails.application.config.middleware.use OmniAuth::Builder do
  provider :discord, ENV['DISCORD_APPID'], ENV['DISCORD_SECRET'], scope: 'identify guilds'
end
```

This is because the value gets overridden to nil.
This PR fixes that issue.