### PR TITLE
Standardize info fields to Omniauth hash schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OmniAuth Discord 
+# OmniAuth Discord
 
 Discord OAuth2 Strategy for OmniAuth.
 
@@ -23,6 +23,15 @@ Here's a quick example, adding the middleware to a Rails app in `config/initiali
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :discord, ENV['DISCORD_APPID'], ENV['DISCORD_SECRET']
+end
+```
+
+By default, Discord does not return a user's email address. Set the scope to
+`email` to get it:
+
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :discord, ENV['DISCORD_APPID'], ENV['DISCORD_SECRET'], scope: 'email'
 end
 ```
 

--- a/lib/omniauth/strategies/discord.rb
+++ b/lib/omniauth/strategies/discord.rb
@@ -19,11 +19,9 @@ module OmniAuth
 
       info do
         {
-          :id            => raw_info['id'],
-          :username      => raw_info['username'],
-          :discriminator => raw_info['discriminator'],
-          :avatar        => raw_info['avatar'],
-          :verified      => raw_info['verified']
+          :name  => raw_info['username'],
+          :email => raw_info['email'],
+          :image => "https://cdn.discordapp.com/avatars/#{raw_info['id']}/#{raw_info['avatar']}"
         }
       end
 
@@ -34,7 +32,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info = access_token.get('users/@me').parsed
+        @raw_info ||= access_token.get('users/@me').parsed
       end
 
       def callback_url


### PR DESCRIPTION
This pull request standardizes the field names returned in the `omniauth.auth` hash based on the [1.0 schema](https://github.com/omniauth/omniauth/wiki/Auth-Hash-Schema).

This request also adds a configuration example to the README file for those that want to include an email address in the response.