### PR TITLE
Update README with multiple scopes example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,25 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 ```
 
-By default, Discord does not return a user's email address. Set the scope to
-`email` to get it:
+By default, Discord does not return a user's email address. Their API uses
+[scopes](https://discordapp.com/developers/docs/topics/oauth2#scopes) to provide
+access to certain resources of a user's account. For example, to get a user's
+email set the scope to `email`.
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :discord, ENV['DISCORD_APPID'], ENV['DISCORD_SECRET'], scope: 'email'
+end
+```
+
+You can pass multiple scopes in the same string. For example to get a user's
+Discord account info set the scope to `email identify`
+
+
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :discord, ENV['DISCORD_APPID'], ENV['DISCORD_SECRET'], scope: 'email
+identify'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Here's a quick example, adding the middleware to a Rails app in `config/initiali
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :discord, ENV['DISCORD_APPID'], ENV['DISCORD_SECRET']
+  provider :discord, ENV['DISCORD_CLIENT_ID'], ENV['DISCORD_CLIENT_SECRET']
 end
 ```
 
@@ -33,7 +33,7 @@ email set the scope to `email`.
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :discord, ENV['DISCORD_APPID'], ENV['DISCORD_SECRET'], scope: 'email'
+  provider :discord, ENV['DISCORD_CLIENT_ID'], ENV['DISCORD_CLIENT_SECRET'], scope: 'email'
 end
 ```
 
@@ -43,7 +43,7 @@ Discord account info set the scope to `email identify`
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :discord, ENV['DISCORD_APPID'], ENV['DISCORD_SECRET'], scope: 'email
+  provider :discord, ENV['DISCORD_CLIENT_ID'], ENV['DISCORD_CLIENT_SECRET'], scope: 'email
 identify'
 end
 ```


### PR DESCRIPTION
For users who are using OAuth for the first time, the process of adding multiple scopes isn't intuitive. For example, someone will probably try `scope: ['email', 'identify']`. This small update to the README explains what's going on and makes it clear how to use multiple scopes.

Also changed the example `ENV` variables to match the Discord API (`:client_id`, `:client_secret`)