### PR TITLE
Fixed formatting issue in multi-scope example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ Discord account info set the scope to `email identify`
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :discord, ENV['DISCORD_CLIENT_ID'], ENV['DISCORD_CLIENT_SECRET'], scope: 'email
-identify'
+  provider :discord, ENV['DISCORD_CLIENT_ID'], ENV['DISCORD_CLIENT_SECRET'], scope: 'email identify'
 end
 ```
 


### PR DESCRIPTION
There was a `\n` typo in my previous PR. `email` and `identify` appeared
on multiple lines - think it was a vim issue. Anyway this corrects it.