### PR TITLE
Add the extra authorize option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 ```
 
+## Specifying addtional permissions
+
+You can also request additional permissions from the user. See the
+[permission help page](https://discordapp.com/developers/docs/topics/permissions#bitwise-permission-flags) for a list of all available options.
+
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :discord, ENV['DISCORD_CLIENT_ID'], ENV['DISCORD_CLIENT_SECRET'], scope: 'identify  bot', permissions: 0x00000010 + 0x10000000
+end
+```
+
+This will request permission to the MANAGE_CHANNELS and the MANAGE_ROLES
+permissions.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/adaoraul/omniauth-discord.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 ```
 
-## Specifying addtional permissions
+## Specifying additional permissions
 
 You can also request additional permissions from the user. See the
 [permission help page](https://discordapp.com/developers/docs/topics/permissions#bitwise-permission-flags) for a list of all available options.

--- a/lib/omniauth/strategies/discord.rb
+++ b/lib/omniauth/strategies/discord.rb
@@ -13,7 +13,7 @@ module OmniAuth
         :token_url     => 'oauth2/token'
       }
 
-      option :authorize_options, [:scope]
+      option :authorize_options, [:scope, :permissions]
 
       uid { raw_info['id'] }
 


### PR DESCRIPTION
Enables you to pass extra permissions in the options.
See https://discordapp.com/developers/docs/topics/oauth2#adding-bots-to-guilds