### PR TITLE
Add permissions to authorized options

### DIFF
--- a/lib/omniauth/strategies/discord.rb
+++ b/lib/omniauth/strategies/discord.rb
@@ -13,7 +13,7 @@ module OmniAuth
         :token_url     => 'oauth2/token'
       }
 
-      option :authorize_options, [:scope]
+      option :authorize_options, [:scope, :permissions]
 
       uid { raw_info['id'] }
 


### PR DESCRIPTION
Permissions is a part of the Discord OAuth interface, and is required when setting permissions for bots authorized over the interface