### PR TITLE
Feature/redirect url

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 ```
 
+You can specify redirect url
+
+
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :discord, ENV['DISCORD_CLIENT_ID'], ENV['DISCORD_CLIENT_SECRET'], scope: 'email identify', redirect_uri: 'https://some_url.com/users/auth/discord/callback'
+end
+```
+
 ## Specifying additional permissions
 
 You can also request additional permissions from the user. See the

--- a/lib/omniauth/strategies/discord.rb
+++ b/lib/omniauth/strategies/discord.rb
@@ -12,7 +12,7 @@ module OmniAuth
              authorize_url: 'oauth2/authorize',
              token_url: 'oauth2/token'
 
-      option :authorize_options, %i[scope permissions]
+      option :authorize_options, %i[scope permissions redirect_uri]
 
       uid { raw_info['id'] }
 
@@ -46,6 +46,7 @@ module OmniAuth
           end
 
           params[:scope] ||= DEFAULT_SCOPE
+          params[:redirect_uri] = options[:redirect_uri] if options[:redirect_uri].present?
         end
       end
     end


### PR DESCRIPTION
For my production server request to discord contains
&redirect_uri=https%3A%2F%2F127.0.0.1%3A3001%2Fusers%2Fauth%2Fdiscord%2Fcallback&

but I need to replace it with real production url
so adding redirect_url to options will help with this