### PR TITLE
allow to set callback url

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 ```
 
+You can set callback url
+
+
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :discord, ENV['DISCORD_CLIENT_ID'], ENV['DISCORD_CLIENT_SECRET'], scope: 'email identify', callback_url: 'https://someurl.com/users/auth/discord/callback'
+end
+```
+
 ## Specifying additional permissions
 
 You can also request additional permissions from the user. See the

--- a/lib/omniauth/strategies/discord.rb
+++ b/lib/omniauth/strategies/discord.rb
@@ -36,7 +36,7 @@ module OmniAuth
 
       def callback_url
         # Discord does not support query parameters
-        full_host + script_name + callback_path
+        options[:callback_url] || (full_host + script_name + callback_path)
       end
 
       def authorize_params


### PR DESCRIPTION
For my production server request to discord contains
&redirect_uri=https%3A%2F%2F127.0.0.1%3A3001%2Fusers%2Fauth%2Fdiscord%2Fcallback&

but I need to replace it with real production url
so adding callback_url to options will help with this