### PR TITLE
Adds support for prompt authorization option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ end
 This will request permission to the MANAGE_CHANNELS and the MANAGE_ROLES
 permissions.
 
+## Specifying the prompt options
+
+Discord looks for the prompt option to indicate if the user should be prompted to reauthorize on sign in. Valid options are 'consent' and 'none'. Note that the use is always prompted to authorize on sign up.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/adaoraul/omniauth-discord.

--- a/lib/omniauth/strategies/discord.rb
+++ b/lib/omniauth/strategies/discord.rb
@@ -12,7 +12,7 @@ module OmniAuth
              authorize_url: 'oauth2/authorize',
              token_url: 'oauth2/token'
 
-      option :authorize_options, %i[scope permissions]
+      option :authorize_options, %i[scope permissions prompt]
 
       uid { raw_info['id'] }
 


### PR DESCRIPTION
Discord allows for the use of the "prompt" option to specify that the user does not have to re-authorize the app with every sign-in. The user is always asked to authorize as part of their original sign-up.

This PR adds prompt as an option that can get passed through to discord.