### PR TITLE
Add webhook info

### DIFF
--- a/lib/omniauth/strategies/discord.rb
+++ b/lib/omniauth/strategies/discord.rb
@@ -27,12 +27,18 @@ module OmniAuth
 
       extra do
         {
-          'raw_info' => raw_info
+          raw_info: raw_info,
+          web_hook_info: web_hook_info
         }
       end
 
       def raw_info
         @raw_info ||= access_token.get('users/@me').parsed
+      end
+
+      def web_hook_info
+        return {} unless access_token.params.key? 'webhook'
+        access_token.params['webhook']
       end
 
       def callback_url


### PR DESCRIPTION
Discord has added a new scope that allows easy creation of incoming webhooks on authorization, this changes to the strategy allows it to return the new info discord provides to the client about the created webhook