### PR TITLE
Only return avatar URL if avatar is present

### DIFF
--- a/lib/omniauth/strategies/discord.rb
+++ b/lib/omniauth/strategies/discord.rb
@@ -21,7 +21,7 @@ module OmniAuth
           name: raw_info['username'],
           email: raw_info['verified'] ? raw_info['email'] : nil,
           # CDN is still cdn.discordapp.com
-          image: "https://cdn.discordapp.com/avatars/#{raw_info['id']}/#{raw_info['avatar']}"
+          image: raw_info['avatar'].present? ? "https://cdn.discordapp.com/avatars/#{raw_info['id']}/#{raw_info['avatar']}" : nil,
         }
       end
 


### PR DESCRIPTION
Discord will respond with an avatar value of `nil` if the user does
not have an avatar uploaded.  Currently, this strategy will return
a URL that only has the user ID and not the avatar hash itself in this case.

This change will return a nil image in the auth hash if no avatar is returned
from discord.

Fixes #29 