### PR TITLE
Upgrade omniauth version

### DIFF
--- a/omniauth-discord.gemspec
+++ b/omniauth-discord.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'omniauth', '~> 2.0.4'
+  spec.add_runtime_dependency 'omniauth', '~> 2.1.0'
   spec.add_runtime_dependency 'omniauth-oauth2'
 
   spec.add_development_dependency 'rack-test'


### PR DESCRIPTION
`omniauth-discord` is blocking `omniauth` upgrade to `2.1.0` (https://github.com/omniauth/omniauth/releases/tag/v2.1.0)
<img width="711" alt="Screen Shot 2022-06-29 at 20 55 17" src="https://user-images.githubusercontent.com/3025661/176564872-5aa8e721-d1b2-4de8-9c7a-44107248b53e.png">
.