### PR TITLE
Update omniauth dependency

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      uses: ruby/setup-ruby@v1.131.0
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/lib/omniauth/discord/version.rb
+++ b/lib/omniauth/discord/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Discord
-    VERSION = '1.0.2'.freeze
+    VERSION = '1.1.0'.freeze
   end
 end

--- a/omniauth-discord.gemspec
+++ b/omniauth-discord.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'omniauth', '~> 2.0.4'
+  spec.add_runtime_dependency 'omniauth', '~> 2.1.0'
   spec.add_runtime_dependency 'omniauth-oauth2'
 
   spec.add_development_dependency 'rack-test'


### PR DESCRIPTION
Thanks for this gem, it's really useful to have a ready-to-use strategy for discord.

I updated the gemspec to allow to use the release `v2.1.0` of the [omniauth gem](https://github.com/omniauth/omniauth/releases/tag/v2.1.0). The only notable change is the bump to the minimum required rack version, and as such should not break anything in this gem.

I also added support für ruby `3.1` and `3.2` to the test matrix to ensure the tests also run on the more recent ruby versions.

I propose updating the version number to `1.1.0`, as I think this change warrants a bump of the minor version, as there might be applications that need to update their rack dependency to use the newer omniauth version (version number is already updated), however it's your decision which version to release :)

Let me know if you need anything else, otherwise I wish you happy holidays!