### PR TITLE
Update raw_info to use `oauth2/@me` path

### DIFF
--- a/lib/omniauth/strategies/discord.rb
+++ b/lib/omniauth/strategies/discord.rb
@@ -31,7 +31,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('users/@me').parsed
+        @raw_info ||= access_token.get('oauth2/@me').parsed
       end
 
       def callback_url


### PR DESCRIPTION
I've just tried to use the `omniauth-discord` gem in a new Rails project of mine but I kept running into "Unauthorized" errors. Checking the Discord OAuth2 docs, the URL to grab details of the currently authenticated user is at `oauth2/@me`, so this PR fixes this.