### PR TITLE
Allow passing `guild_id`

### DIFF
--- a/lib/omniauth/strategies/discord.rb
+++ b/lib/omniauth/strategies/discord.rb
@@ -12,7 +12,7 @@ module OmniAuth
              authorize_url: 'oauth2/authorize',
              token_url: 'oauth2/token'
 
-      option :authorize_options, %i[scope permissions prompt]
+      option :authorize_options, %i[scope guild_id permissions prompt]
 
       uid { raw_info['id'] }
 


### PR DESCRIPTION
This PR adds the ability to allow `guild_id` to be sent in the URL